### PR TITLE
fix: disable 'noUnusedLocals' property in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
     "noUnusedParameters": true,
-    "noUnusedLocals": false
+    "noUnusedLocals": false,
 
     /* If transpiling with TypeScript: */
     "module": "esnext",


### PR DESCRIPTION
# 🧩 Pull Request

Thank you for contributing to **React OL**!  
Please complete all relevant sections below before submitting your PR.

---

## 📖 Description

The TypeScript compiler was reporting 'React' is declared but its value is never read for JSX files, even though React is only imported for typing or compatibility reasons. Since these imports are required in some cases but not referenced directly, the noUnusedLocals rule produces unnecessary warnings.
Disabling this option reduces noise in the build output and avoids cluttering the codebase with suppress-comments for harmless unused imports.

Fixes #43 

---

## ✅ Type of Change

Please check the option(s) that apply:

- [x] 🐛 **Bug fix** (non-breaking change that fixes an issue)
- [ ] ✨ **New feature** (non-breaking change that adds functionality)
- [ ] ⚠️ **Breaking change** (fix or feature that would cause existing behavior to change)
- [ ] 🧹 **Chore / Maintenance** (build, CI, release, or repo config)
- [ ] 🧪 **Test** (adding or improving test coverage)
- [ ] 📝 **Docs** (documentation only)

---

## 🧠 Summary of Changes

- Disable noUnusedLocals to avoid noise from unused React imports

---

## 🧩 How Has This Been Tested?

<!-- Describe your testing process or provide a link to the demo app. -->
- [ ] Unit tests (`npm test`)
- [x] Manual test in the example app (`npm run dev`)
- [x] Other (please specify):

---

## 🔍 Screenshots / Demo (if applicable)

<!-- Add screenshots, screen recordings, or gifs if this affects UI behavior. -->

---

## 🧾 Checklist

Before submitting this PR, please confirm:

- [x] I followed the **Conventional Commits** format (e.g., `feat:`, `fix:`, `chore:`).
- [x] I’ve read the [CONTRIBUTING.md](./CONTRIBUTING.md).
- [x] I ran `npm run lint` and `npm test` locally and they passed.
- [x] I’ve added or updated documentation as needed.
- [x] I’ve linked all related issues and discussions.
- [x] I’ve checked that this PR doesn’t duplicate existing open PRs.
- [x] I’ve added cleanup for all event listeners and effects (if applicable to OL).

---

## 🧭 Additional Notes

<!-- Add any additional information reviewers should know. -->

